### PR TITLE
ポスト内のURLをリンクにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,5 @@ end
 
 # Windows ではタイムゾーン情報用の tzinfo-data gem を含める必要があります
 # gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "rinku"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,7 @@ GEM
     reline (0.3.1)
       io-console (~> 0.5)
     rexml (3.2.5)
+    rinku (2.0.6)
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
@@ -358,6 +359,7 @@ DEPENDENCIES
   puma (= 5.6.4)
   rails (= 7.0.4)
   rails-controller-testing (= 1.0.5)
+  rinku
   sassc-rails (= 2.1.2)
   selenium-webdriver (= 4.2.0)
   sprockets-rails (= 3.4.2)

--- a/app/views/microposts/_micropost.html.erb
+++ b/app/views/microposts/_micropost.html.erb
@@ -2,7 +2,7 @@
   <%= link_to gravatar_for(micropost.user, size: 50), micropost.user %>
   <span class="user"><%= link_to micropost.user.name, micropost.user %></span>
   <span class="content">
-    <%= micropost.content %>
+    <%= raw Rinku.auto_link((micropost.content), :urls, 'target="_blank"') %>
     <% if micropost.image.attached? %>
       <%= image_tag micropost.image.variant(:display) %>
     <% end %>


### PR DESCRIPTION
実装したこと
・ポスト内のURLが外部リンクになる機能の実装
・上記の機能実装のためrinkuの導入

以下参考スクリーンショット
<img width="404" alt="image" src="https://github.com/user-attachments/assets/b9129534-e868-4c82-9013-271963221d7c">
